### PR TITLE
Allow any non hyphen character as a switch

### DIFF
--- a/lib/getopt/long.rb
+++ b/lib/getopt/long.rb
@@ -94,9 +94,9 @@ module Getopt
       end
 
       re_long     = /^(--\w+[-\w+]*)?$/
-      re_short    = /^(-\w)$/
-      re_long_eq  = /^(--\w+[-\w+]*)?=(.*?)$|(-\w?)=(.*?)$/
-      re_short_sq = /^(-\w)(\S+?)$/
+      re_short    = /^(-[^\s-])$/
+      re_long_eq  = /^(--\w+[-\w+]*)?=(.*?)$|(-[^\s-])=(.*?)$/
+      re_short_sq = /^(-[^\s-])(\S+?)$/
 
       ARGV.each_with_index do |opt, index|
         # Allow either -x -v or -xv style for single char args

--- a/lib/getopt/std.rb
+++ b/lib/getopt/std.rb
@@ -46,7 +46,7 @@ module Getopt
     def self.getopts(switches)
       args  = switches.split(/ */)
       hash  = {}
-      regex = /^-(\w)\s*(\w*)/s
+      regex = /^-([^\s-])\s*(\S*)/s
 
       while !ARGV.empty? && regex.match(ARGV.first)
         first, rest = Regexp.last_match(1), Regexp.last_match(2)

--- a/spec/getopt_long_spec.rb
+++ b/spec/getopt_long_spec.rb
@@ -112,6 +112,19 @@ RSpec.describe Getopt::Long do
     expect(@opts['b']).to eq('world')
   end
 
+  example 'getopts long accepts question mark as a short switch' do
+    ARGV.push('-?')
+
+    expect{
+      @opts = described_class.getopts(
+        ['--help', '-?', Getopt::BOOLEAN]
+      )
+    }.not_to raise_error
+
+    expect(@opts['help']).to be(true)
+    expect(@opts['?']).to be(true)
+  end
+
   example 'getopts long increment type works as expected' do
     ARGV.push('-m', '-m')
 

--- a/spec/getopt_std_spec.rb
+++ b/spec/getopt_std_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe Getopt::Std do
     expect(described_class.getopts('ID')).to eq({'I' => true, 'D' => true})
   end
 
+  example 'getopts accepts question mark as a switch' do
+    ARGV.push('-?')
+    expect(described_class.getopts('?')).to eq({'?' => true})
+  end
+
   example 'getopts with separated switches and mandatory argument' do
     ARGV.push('-o', 'hello', '-I', '-D')
     expect(described_class.getopts('o:ID')).to eq({'o' => 'hello', 'I' => true, 'D' => true})


### PR DESCRIPTION
There was a regression in 1.7. This PR updates the regex to make it more flexible, allowing any character (except hyphens and spaces) to be used as a switch.

Addresses https://github.com/djberg96/getopt/issues/11